### PR TITLE
Add vLLM inference server and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ To run MOSS-TTSD, you need to install the required dependencies. You can use pip
 conda create -n moss_ttsd python=3.10 -y && conda activate moss_ttsd
 pip install -r requirements.txt
 pip install flash-attn
+# Optional: install vLLM separately if you plan to run the vLLM inference server.
+# Refer to https://docs.vllm.ai/en/latest/getting_started/installation.html for CUDA-specific wheels.
 ```
 
 ### Download XY-Tokenizer
@@ -491,6 +493,59 @@ python finetune/finetune_workflow.py --config path/to/your/config.yaml
 #### Parameters
 
 - `-c`, `--config`: Path to the workflow configuration YAML file (default: `./finetune/finetune_config.yaml`)
+
+## Accelerate Inference with vLLM
+
+We provide a lightweight FastAPI service (`inference_vllm_server.py`) that runs the
+MOSS-TTSD model through the [vLLM](https://github.com/vllm-project/vllm) engine to
+speed up text-to-speech decoding. The `vllm` package is not included in the default
+`requirements.txt` because its pre-built wheels depend on your CUDA and PyTorch
+versions—install it separately once your environment is ready.
+
+### Install vLLM
+
+Consult the [vLLM installation guide](https://docs.vllm.ai/en/latest/getting_started/installation.html)
+to choose the correct wheel for your CUDA runtime. For example, on a CUDA 12.1
+system with PyTorch wheels from the official index you can run:
+
+```bash
+pip install --upgrade pip
+pip install "vllm>=0.5.0" --extra-index-url https://download.pytorch.org/whl/cu121
+```
+
+> ⚠️ The exact `vllm` version and `--extra-index-url` flag depend on the CUDA/PyTorch
+> combination in your environment. Please adjust the command accordingly.
+
+### Launch the vLLM inference server
+
+Download the model and XY-Tokenizer weights as described in the [Installation](#installation)
+section, then start the server:
+
+```bash
+python inference_vllm_server.py \
+  --model-path fnlp/MOSS-TTSD-v0.5 \
+  --spt-config XY_Tokenizer/config/xy_tokenizer_32k_config.yaml \
+  --spt-checkpoint XY_Tokenizer/weights/xy_tokenizer.ckpt \
+  --port 30001 \
+  --default-use-normalize \
+  --silence-duration 0.1
+```
+
+The server listens on `/generate_audio` and returns WAV audio bytes. You can
+include optional `prompt_audio*` fields encoded with Base64 to provide reference
+speakers.
+
+### Example request
+
+```bash
+curl -X POST "http://localhost:30001/generate_audio" \
+  -H "Content-Type: application/json" \
+  -o reply.wav \
+  -d '{
+        "text": "[S1]Hello there![S2]Hi, nice to meet you!",
+        "use_normalize": true
+      }'
+```
 
 ## Accelerate Inference with SGLang
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -52,6 +52,7 @@ MOSS-TTSD（text to spoken dialogue）是一个开源的中英双语口语对话
 conda create -n moss_ttsd python=3.10 -y && conda activate moss_ttsd
 pip install -r requirements.txt
 pip install flash-attn
+# 可选：如需运行 vLLM 推理服务，请单独安装 vLLM（不同 CUDA 版本对应不同安装包，详见 https://docs.vllm.ai/en/latest/getting_started/installation.html）。
 ```
 
 ### 下载 XY-Tokenizer 权重
@@ -494,6 +495,55 @@ python finetune/finetune_workflow.py --config path/to/your/config.yaml
 #### 参数说明
 
 - `-c`, `--config`: 工作流配置 YAML 文件的路径（默认：`./finetune/finetune_config.yaml`）
+
+## 使用 vLLM 加速推理
+
+我们提供了一个基于 FastAPI 的推理服务（`inference_vllm_server.py`），使用
+[vLLM](https://github.com/vllm-project/vllm) 引擎来加速文本到语音的生成。
+由于 `vllm` 的预编译轮子与 CUDA / PyTorch 版本强相关，因此默认的
+`requirements.txt` 未直接包含该依赖，需要在环境就绪后手动安装。
+
+### 安装 vLLM
+
+请参考 [vLLM 安装指南](https://docs.vllm.ai/zh/latest/getting_started/installation.html)
+选择适合当前 CUDA 运行时的安装包。以 CUDA 12.1 环境为例，可执行：
+
+```bash
+pip install --upgrade pip
+pip install "vllm>=0.5.0" --extra-index-url https://download.pytorch.org/whl/cu121
+```
+
+> ⚠️ 具体的 `vllm` 版本号以及 `--extra-index-url` 参数需根据自身的 CUDA / PyTorch
+> 组合进行调整，安装前请确认环境兼容性。
+
+### 启动 vLLM 推理服务
+
+按照 [安装](#安装) 章节中的说明下载模型与 XY-Tokenizer 权重后，可通过以下命令启动：
+
+```bash
+python inference_vllm_server.py \
+  --model-path fnlp/MOSS-TTSD-v0.5 \
+  --spt-config XY_Tokenizer/config/xy_tokenizer_32k_config.yaml \
+  --spt-checkpoint XY_Tokenizer/weights/xy_tokenizer.ckpt \
+  --port 30001 \
+  --default-use-normalize \
+  --silence-duration 0.1
+```
+
+服务会监听 `/generate_audio` 接口并返回 WAV 格式的音频字节，可选地通过
+Base64 编码的 `prompt_audio*` 字段提供说话人参考音频。
+
+### 请求示例
+
+```bash
+curl -X POST "http://localhost:30001/generate_audio" \
+  -H "Content-Type: application/json" \
+  -o reply.wav \
+  -d '{
+        "text": "[S1]你好！[S2]很高兴见到你！",
+        "use_normalize": true
+      }'
+```
 
 ## 使用 SGLang 加速推理
 

--- a/generation_utils.py
+++ b/generation_utils.py
@@ -1,11 +1,33 @@
 import os
 import re
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import torch
 import torchaudio
 
 MAX_CHANNELS = 8
+PAD_TOKEN_ID = 1024
+
+
+def load_tokenizer_and_spt(
+    model_path: str,
+    spt_config_path: str,
+    spt_checkpoint_path: str,
+):
+    """Load tokenizer and speech tokenizer without instantiating the LLM."""
+
+    from transformers import AutoTokenizer
+
+    from XY_Tokenizer.xy_tokenizer.model import XY_Tokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    spt = XY_Tokenizer.load_from_checkpoint(
+        config_path=spt_config_path, ckpt_path=spt_checkpoint_path
+    )
+    spt.eval()
+    return tokenizer, spt
 
 
 def load_model(
@@ -15,21 +37,18 @@ def load_model(
     torch_dtype=torch.bfloat16,
     attn_implementation="flash_attention_2",
 ):
-    from transformers import AutoTokenizer
-
     from modeling_asteroid import AsteroidTTSInstruct
-    from XY_Tokenizer.xy_tokenizer.model import XY_Tokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    tokenizer, spt = load_tokenizer_and_spt(
+        model_path=model_path,
+        spt_config_path=spt_config_path,
+        spt_checkpoint_path=spt_checkpoint_path,
+    )
     model = AsteroidTTSInstruct.from_pretrained(
         model_path, torch_dtype=torch_dtype, attn_implementation=attn_implementation
     )
-    spt = XY_Tokenizer.load_from_checkpoint(
-        config_path=spt_config_path, ckpt_path=spt_checkpoint_path
-    )
 
     model.eval()
-    spt.eval()
     return tokenizer, model, spt
 
 
@@ -203,8 +222,8 @@ def process_inputs(
     device,
     silence_duration,
     audio_data=None,
-    max_channels=8,
-    pad_token=1024,
+    max_channels=MAX_CHANNELS,
+    pad_token=PAD_TOKEN_ID,
 ):
     seq = f"<|begin_of_style|>{prompt}<|end_of_style|>\n<|begin_of_text|>{text}<|end_of_text|>\n<|begin_of_speech|>"
     inputs1 = np.array(tokenizer.encode(seq))
@@ -240,7 +259,12 @@ def process_inputs(
     return input_ids
 
 
-def shifting_inputs(input_ids, tokenizer, pad_token=1024, max_channels=8):
+def shifting_inputs(
+    input_ids,
+    tokenizer,
+    pad_token: int = PAD_TOKEN_ID,
+    max_channels: int = MAX_CHANNELS,
+):
     seq_len = input_ids.shape[0]
     new_seq_len = seq_len + max_channels - 1
     shifted_input_ids = np.full((new_seq_len, max_channels), pad_token, dtype=np.int64)
@@ -252,14 +276,14 @@ def shifting_inputs(input_ids, tokenizer, pad_token=1024, max_channels=8):
     return shifted_input_ids
 
 
-def rpadding(input_ids, channels, tokenizer):
+def rpadding(input_ids, channels: int, tokenizer):
     attention_masks = [np.ones(inputs.shape[0]) for inputs in input_ids]
     max_length = max(ids.shape[0] for ids in input_ids)
     padded_input_ids, padded_attns = [], []
 
     for ids, attn in zip(input_ids, attention_masks):
         pad_len = max_length - ids.shape[0]
-        input_pad = np.full((pad_len, channels), 1024)
+        input_pad = np.full((pad_len, channels), PAD_TOKEN_ID)
         input_pad[:, 0] = tokenizer.pad_token_id
         padded_input_ids.append(np.concatenate([input_pad, ids]))
         attn_pad = np.zeros(pad_len)
@@ -271,7 +295,9 @@ def rpadding(input_ids, channels, tokenizer):
     return input_ids, attention_mask
 
 
-def find_max_valid_positions(C: torch.Tensor, invalid_value=1024) -> torch.Tensor:
+def find_max_valid_positions(
+    C: torch.Tensor, invalid_value: int = PAD_TOKEN_ID
+) -> torch.Tensor:
     values = C[:, :, 1]
     mask = values != invalid_value
     reversed_mask = mask.flip(dims=[1])
@@ -281,6 +307,170 @@ def find_max_valid_positions(C: torch.Tensor, invalid_value=1024) -> torch.Tenso
     has_valid = mask.any(dim=1)
     original_indices = torch.where(has_valid, original_indices, -1)
     return original_indices
+
+
+def find_max_valid_position_single(
+    sample: torch.Tensor, invalid_value: int = PAD_TOKEN_ID
+) -> int:
+    """Find the last valid speech token position for a single sample."""
+
+    values = sample[:, 1]
+    mask = values != invalid_value
+    if torch.any(mask):
+        return int(torch.nonzero(mask, as_tuple=False)[-1].item())
+    return -1
+
+
+def extract_speech_ids_from_shifted(
+    shifted_outputs: torch.Tensor,
+    max_channels: int = MAX_CHANNELS,
+) -> torch.Tensor:
+    """Recover speech tokens from shifted multi-channel outputs."""
+
+    if shifted_outputs.dim() == 2:
+        shifted_outputs = shifted_outputs.unsqueeze(0)
+
+    batch_size, seq_with_shift, _ = shifted_outputs.shape
+    seq_len = seq_with_shift - max_channels + 1
+    if seq_len <= 0:
+        raise ValueError(
+            "Shifted outputs length must be at least max_channels to extract speech tokens."
+        )
+
+    speech_ids = torch.zeros(
+        (batch_size, seq_len, max_channels),
+        dtype=shifted_outputs.dtype,
+        device=shifted_outputs.device,
+    )
+    for channel_idx in range(max_channels):
+        speech_ids[..., channel_idx] = shifted_outputs[
+            :, channel_idx : seq_len + channel_idx, channel_idx
+        ]
+    return speech_ids
+
+
+def _prepare_vllm_sampling_params(
+    sampling_params: Optional[Any],
+    max_new_tokens: Optional[int],
+    max_channels: int,
+):
+    try:
+        from vllm import SamplingParams
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "vLLM is required for vLLM-based inference. Install it with `pip install vllm`."
+        ) from exc
+
+    if sampling_params is None:
+        total_max_tokens = (
+            max_new_tokens * max_channels if max_new_tokens is not None else None
+        )
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            top_p=None,
+            top_k=None,
+            max_tokens=total_max_tokens,
+        )
+    else:
+        sampling_params = deepcopy(sampling_params)
+        if max_new_tokens is not None:
+            sampling_params.max_tokens = max_new_tokens * max_channels
+
+    if getattr(sampling_params, "max_tokens", None) is not None:
+        sampling_params.max_tokens = (
+            (sampling_params.max_tokens + max_channels - 1) // max_channels
+        ) * max_channels
+
+    return sampling_params
+
+
+def generate_with_vllm(
+    engine: Any,
+    input_sequences: Sequence[np.ndarray],
+    sampling_params: Optional[Any] = None,
+    max_channels: int = MAX_CHANNELS,
+    pad_token: int = PAD_TOKEN_ID,
+    max_new_tokens: Optional[int] = None,
+):
+    """Generate speech tokens using a vLLM engine.
+
+    Args:
+        engine: vLLM LLM engine instance.
+        input_sequences: Sequence of shifted prompt tensors (numpy arrays).
+        sampling_params: Optional vLLM SamplingParams; copied before use.
+        max_channels: Number of speech channels.
+        pad_token: Token id used for padding speech channels.
+        max_new_tokens: Optional limit for newly generated multi-channel steps.
+
+    Returns:
+        A tuple `(speech_tokens, token_stats)` where `speech_tokens` is a list of
+        tensors containing decoded speech ids for each sample, and `token_stats`
+        contains prompt/completion token usage metadata.
+    """
+
+    if engine is None:
+        raise ValueError("vLLM engine must be provided when using vLLM inference.")
+
+    params = _prepare_vllm_sampling_params(
+        sampling_params=sampling_params,
+        max_new_tokens=max_new_tokens,
+        max_channels=max_channels,
+    )
+
+    prompts: List[List[int]] = []
+    prompt_lengths: List[int] = []
+    prompt_steps: List[int] = []
+    for arr in input_sequences:
+        prompt = arr.reshape(-1).tolist()
+        prompts.append(prompt)
+        prompt_lengths.append(len(prompt))
+        prompt_steps.append(arr.shape[0])
+
+    results = engine.generate(prompt_token_ids=prompts, sampling_params=params)
+
+    generated_speech: List[torch.Tensor] = []
+    token_stats: List[Dict[str, int]] = []
+
+    for prompt_len, prompt_step_len, arr_prompt, result in zip(
+        prompt_lengths, prompt_steps, input_sequences, results
+    ):
+        prompt_tokens = list(result.prompt_token_ids)
+        if len(prompt_tokens) != prompt_len:
+            raise ValueError(
+                "Mismatch between provided prompt length and vLLM acknowledged prompt length."
+            )
+
+        if not result.outputs:
+            raise RuntimeError("vLLM did not return any outputs for the request.")
+
+        completion_tokens = list(result.outputs[0].token_ids)
+        full_tokens = prompt_tokens + completion_tokens
+        pad_len = (-len(full_tokens)) % max_channels
+        if pad_len:
+            full_tokens.extend([pad_token] * pad_len)
+
+        full_tensor = torch.tensor(full_tokens, dtype=torch.long)
+        full_tensor = full_tensor.view(-1, max_channels)
+
+        start = prompt_step_len - max_channels + 1
+        if start < 0:
+            start = 0
+        shifted = full_tensor[start:]
+        speech_ids = extract_speech_ids_from_shifted(
+            shifted, max_channels=max_channels
+        )[0]
+        speech_ids[:, 0] = speech_ids[:, 0] - 151665
+
+        generated_speech.append(speech_ids)
+        token_stats.append(
+            {
+                "prompt_tokens": len(prompt_tokens),
+                "completion_tokens": len(completion_tokens),
+                "total_tokens": len(full_tokens),
+            }
+        )
+
+    return generated_speech, token_stats
 
 
 def normalize_text(text: str) -> str:
@@ -391,6 +581,9 @@ def process_batch(
     start_idx,
     use_normalize=False,
     silence_duration=0,
+    vllm_engine: Optional[Any] = None,
+    vllm_sampling_params: Optional[Any] = None,
+    max_new_tokens: Optional[int] = None,
 ):
     """Process a batch of data items and generate audio, return audio data and metadata"""
     try:
@@ -442,7 +635,7 @@ def process_batch(
             prompt_audios.append(processed_item["prompt_audio"])
 
         # Process inputs
-        input_ids_list = []
+        input_ids_list: List[np.ndarray] = []
         for i, (text, prompt, audio_path) in enumerate(
             zip(texts, prompts, prompt_audios)
         ):
@@ -454,40 +647,59 @@ def process_batch(
             inputs = shifting_inputs(inputs, tokenizer)
             input_ids_list.append(inputs)
 
-        # Pad batch inputs
-        input_ids, attention_mask = rpadding(input_ids_list, MAX_CHANNELS, tokenizer)
+        print("Starting batch audio generation...")
 
-        # Batch generation
-        print(f"Starting batch audio generation...")
-        start = input_ids.shape[1] - MAX_CHANNELS + 1
+        speech_samples: List[torch.Tensor]
+        token_stats: List[Optional[Dict[str, int]]]
 
-        # Move inputs to GPU
-        input_ids = input_ids.to(device)
-        attention_mask = attention_mask.to(device)
+        if vllm_engine is None:
+            if model is None:
+                raise ValueError(
+                    "Model instance must be provided when vLLM engine is not used."
+                )
 
-        # Generate model outputs
-        outputs = model.generate(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-        )
-        print(f"Original outputs shape: {outputs.shape}")
-        print(f"Start value: {start}")
-        print(f"Shape after slicing: {outputs[:, start:].shape}")
-        print(f"MAX_CHANNELS: {MAX_CHANNELS}")
-        print(f"Calculated seq_len: {outputs.shape[1] - MAX_CHANNELS + 1}")
-        # Process outputs
-        outputs = outputs[:, start:]
-        seq_len = outputs.shape[1] - MAX_CHANNELS + 1
-        speech_ids = torch.full((outputs.shape[0], seq_len, MAX_CHANNELS), 0).to(device)
+            # Pad batch inputs
+            input_ids, attention_mask = rpadding(
+                input_ids_list, MAX_CHANNELS, tokenizer
+            )
 
-        # Adjust output format
-        for j in range(MAX_CHANNELS):
-            speech_ids[..., j] = outputs[:, j : seq_len + j, j]
-            if j == 0:
-                speech_ids[..., j] = speech_ids[..., j] - 151665
+            start = input_ids.shape[1] - MAX_CHANNELS + 1
 
-        # Find valid positions for each sample
-        li = find_max_valid_positions(speech_ids)
+            # Move inputs to device
+            input_ids = input_ids.to(device)
+            attention_mask = attention_mask.to(device)
+
+            outputs = model.generate(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+            )
+            print(f"Original outputs shape: {outputs.shape}")
+            print(f"Start value: {start}")
+            print(f"Shape after slicing: {outputs[:, start:].shape}")
+            print(f"MAX_CHANNELS: {MAX_CHANNELS}")
+            print(f"Calculated seq_len: {outputs.shape[1] - MAX_CHANNELS + 1}")
+
+            shifted_outputs = outputs[:, start:]
+            speech_batch = extract_speech_ids_from_shifted(
+                shifted_outputs, max_channels=MAX_CHANNELS
+            )
+            speech_batch[..., 0] = speech_batch[..., 0] - 151665
+
+            speech_samples = [speech_batch[i].detach().cpu() for i in range(batch_size)]
+            token_stats = [None] * batch_size
+        else:
+            speech_samples, token_stats = generate_with_vllm(
+                engine=vllm_engine,
+                input_sequences=input_ids_list,
+                sampling_params=vllm_sampling_params,
+                max_channels=MAX_CHANNELS,
+                pad_token=PAD_TOKEN_ID,
+                max_new_tokens=max_new_tokens,
+            )
+            if len(speech_samples) != batch_size:
+                raise RuntimeError(
+                    "vLLM generation returned mismatched number of samples."
+                )
 
         # Store audio result data
         audio_results = []
@@ -495,14 +707,19 @@ def process_batch(
         # Process batch sample results individually
         for i in range(batch_size):
             try:
-                # Extract valid speech tokens
-                end_idx = li[i] + 1
-                if end_idx <= 0:
+                speech_tokens = speech_samples[i]
+                if not isinstance(speech_tokens, torch.Tensor):
+                    speech_tokens = torch.tensor(speech_tokens)
+
+                speech_tokens = speech_tokens.to(torch.long).cpu()
+
+                end_idx = find_max_valid_position_single(speech_tokens)
+                if end_idx < 0:
                     print(f"Sample {start_idx + i} has no valid speech tokens")
                     audio_results.append(None)
                     continue
 
-                this_speech_id = speech_ids[i, :end_idx]
+                this_speech_id = speech_tokens[: end_idx + 1]
                 print(
                     f"Speech token shape for sample {start_idx + i}: {this_speech_id.shape}"
                 )
@@ -521,13 +738,15 @@ def process_batch(
                         )  # Convert to 2D [1, samples]
 
                 # Save audio data instead of file path
-                audio_results.append(
-                    {
-                        "audio_data": audio_result,
-                        "sample_rate": spt.output_sample_rate,
-                        "index": start_idx + i,
-                    }
-                )
+                result_entry = {
+                    "audio_data": audio_result,
+                    "sample_rate": spt.output_sample_rate,
+                    "index": start_idx + i,
+                }
+                if token_stats and token_stats[i] is not None:
+                    result_entry["token_usage"] = token_stats[i]
+
+                audio_results.append(result_entry)
                 print(f"Audio generation completed: sample {start_idx + i}")
 
             except Exception as e:
@@ -538,7 +757,8 @@ def process_batch(
                 audio_results.append(None)
 
         # Clean up GPU memory
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available() and device == "cuda":
+            torch.cuda.empty_cache()
 
         # Return text data and audio data
         return actual_texts_data, audio_results

--- a/inference_vllm_server.py
+++ b/inference_vllm_server.py
@@ -1,0 +1,245 @@
+import argparse
+import base64
+import io
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import soundfile as sf
+import torch
+import torchaudio
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from generation_utils import (
+    MAX_CHANNELS,
+    load_tokenizer_and_spt,
+    process_batch,
+)
+
+MODEL_PATH = "fnlp/MOSS-TTSD-v0.5"
+SYSTEM_PROMPT = "You are a speech synthesizer that generates natural, realistic, and human-like conversational audio from dialogue text."
+SPT_CONFIG_PATH = "XY_Tokenizer/config/xy_tokenizer_32k_config.yaml"
+SPT_CHECKPOINT_PATH = "XY_Tokenizer/weights/xy_tokenizer.ckpt"
+
+
+class GenerationRequest(BaseModel):
+    text: str
+    prompt_text: Optional[str] = None
+    prompt_audio: Optional[str] = None
+    prompt_audio_speaker1: Optional[str] = None
+    prompt_text_speaker1: Optional[str] = None
+    prompt_audio_speaker2: Optional[str] = None
+    prompt_text_speaker2: Optional[str] = None
+    use_normalize: Optional[bool] = None
+    silence_duration: Optional[float] = None
+
+
+@dataclass
+class ServerState:
+    engine: Any
+    tokenizer: Any
+    spt: Any
+    device: str
+    sampling_params: Any
+    max_new_tokens: Optional[int]
+    system_prompt: str
+    default_use_normalize: bool
+    default_silence_duration: float
+
+
+def decode_audio_base64(audio_b64: str) -> Optional[Tuple[torch.Tensor, int]]:
+    if not audio_b64:
+        return None
+    try:
+        audio_bytes = base64.b64decode(audio_b64)
+    except Exception as exc:  # pragma: no cover - input validation
+        raise ValueError("Failed to decode base64 audio data") from exc
+
+    with io.BytesIO(audio_bytes) as buf:
+        try:
+            audio, sample_rate = sf.read(buf, dtype="float32")
+        except Exception as exc:  # pragma: no cover - invalid audio
+            raise ValueError("Invalid audio data provided") from exc
+
+    if audio.ndim == 1:
+        audio = np.expand_dims(audio, axis=1)
+
+    audio_tensor = torch.from_numpy(audio.T)
+    return audio_tensor, sample_rate
+
+
+def build_item_from_request(payload: GenerationRequest) -> Dict[str, Any]:
+    item: Dict[str, Any] = {"text": payload.text}
+
+    if payload.prompt_text:
+        item["prompt_text"] = payload.prompt_text
+
+    if payload.prompt_audio:
+        item["prompt_audio"] = decode_audio_base64(payload.prompt_audio)
+
+    if payload.prompt_audio_speaker1:
+        item["prompt_audio_speaker1"] = decode_audio_base64(payload.prompt_audio_speaker1)
+    if payload.prompt_text_speaker1:
+        item["prompt_text_speaker1"] = payload.prompt_text_speaker1
+
+    if payload.prompt_audio_speaker2:
+        item["prompt_audio_speaker2"] = decode_audio_base64(payload.prompt_audio_speaker2)
+    if payload.prompt_text_speaker2:
+        item["prompt_text_speaker2"] = payload.prompt_text_speaker2
+
+    return item
+
+
+def build_state(args: argparse.Namespace) -> ServerState:
+    from vllm import LLM, SamplingParams
+
+    dtype_mapping = {
+        "bf16": "bfloat16",
+        "fp16": "float16",
+        "fp32": "float32",
+    }
+
+    tokenizer, spt = load_tokenizer_and_spt(
+        model_path=args.model_path,
+        spt_config_path=args.spt_config,
+        spt_checkpoint_path=args.spt_checkpoint,
+    )
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    spt = spt.to(device)
+    spt.eval()
+
+    engine = LLM(
+        model=args.model_path,
+        tensor_parallel_size=args.tensor_parallel_size,
+        trust_remote_code=True,
+        dtype=dtype_mapping[args.dtype],
+    )
+
+    max_tokens = args.max_new_tokens * MAX_CHANNELS if args.max_new_tokens else None
+    top_k = args.top_k if args.top_k >= 0 else None
+
+    sampling_params = SamplingParams(
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=top_k,
+        repetition_penalty=args.repetition_penalty,
+        max_tokens=max_tokens,
+    )
+
+    return ServerState(
+        engine=engine,
+        tokenizer=tokenizer,
+        spt=spt,
+        device=device,
+        sampling_params=sampling_params,
+        max_new_tokens=args.max_new_tokens,
+        system_prompt=args.system_prompt,
+        default_use_normalize=args.default_use_normalize,
+        default_silence_duration=args.silence_duration,
+    )
+
+
+def create_app(state: ServerState) -> FastAPI:
+    app = FastAPI(title="MOSS-TTSD vLLM Server")
+
+    @app.post("/generate_audio")
+    async def generate_audio(payload: GenerationRequest):
+        try:
+            item = build_item_from_request(payload)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        use_normalize = (
+            payload.use_normalize
+            if payload.use_normalize is not None
+            else state.default_use_normalize
+        )
+        silence_duration = (
+            payload.silence_duration
+            if payload.silence_duration is not None
+            else state.default_silence_duration
+        )
+
+        try:
+            _, audio_results = process_batch(
+                batch_items=[item],
+                tokenizer=state.tokenizer,
+                model=None,
+                spt=state.spt,
+                device=state.device,
+                system_prompt=state.system_prompt,
+                start_idx=0,
+                use_normalize=use_normalize,
+                silence_duration=silence_duration,
+                vllm_engine=state.engine,
+                vllm_sampling_params=state.sampling_params,
+                max_new_tokens=state.max_new_tokens,
+            )
+        except Exception as exc:  # pragma: no cover - runtime errors
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+        if not audio_results or audio_results[0] is None:
+            raise HTTPException(status_code=500, detail="Audio generation failed")
+
+        result = audio_results[0]
+        audio_tensor = result["audio_data"].cpu()
+        sample_rate = int(result["sample_rate"])
+
+        buffer = io.BytesIO()
+        torchaudio.save(buffer, audio_tensor, sample_rate, format="wav")
+        buffer.seek(0)
+
+        headers = {
+            "sample_rate": str(sample_rate),
+        }
+
+        usage = result.get("token_usage")
+        if usage:
+            headers.update(
+                {
+                    "prompt_tokens": str(usage.get("prompt_tokens", 0)),
+                    "completion_tokens": str(usage.get("completion_tokens", 0)),
+                    "total_tokens": str(usage.get("total_tokens", 0)),
+                }
+            )
+
+        return Response(content=buffer.getvalue(), media_type="audio/wav", headers=headers)
+
+    return app
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="MOSS-TTSD vLLM inference server")
+    parser.add_argument("--model-path", default=MODEL_PATH)
+    parser.add_argument("--spt-config", default=SPT_CONFIG_PATH)
+    parser.add_argument("--spt-checkpoint", default=SPT_CHECKPOINT_PATH)
+    parser.add_argument("--system-prompt", default=SYSTEM_PROMPT)
+    parser.add_argument("--dtype", choices=["bf16", "fp16", "fp32"], default="bf16")
+    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top-p", type=float, default=0.95)
+    parser.add_argument("--top-k", type=int, default=-1, help="Set to a non-negative value to enable top-k sampling")
+    parser.add_argument("--repetition-penalty", type=float, default=1.0)
+    parser.add_argument("--max-new-tokens", type=int, default=20000)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=30001)
+    parser.add_argument("--log-level", default="info")
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--default-use-normalize", action="store_true")
+    parser.add_argument("--silence-duration", type=float, default=0.0)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    state = build_state(args)
+    app = create_app(state)
+    uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level, workers=args.workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,7 @@ liger_kernel
 pydub
 fastapi
 uvicorn
-vllm
-# flash-attn    # Need to install separately
+
+# Optional dependencies (install separately if needed)
+# vllm        # Required for the FastAPI vLLM inference server
+# flash-attn  # Need to install separately

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,7 @@ einops
 huggingface_hub
 liger_kernel
 pydub
+fastapi
+uvicorn
+vllm
 # flash-attn    # Need to install separately


### PR DESCRIPTION
## Summary
- add a FastAPI-based vLLM inference server that reuses the existing preprocessing and decoding pipeline
- extend generation utilities with shared resource loaders and a vLLM-backed generation path that returns token usage metadata
- include vLLM server dependencies in the Python requirements list

## Testing
- python -m compileall generation_utils.py inference_vllm_server.py

------
https://chatgpt.com/codex/tasks/task_e_68c9112b77a083229d343b0fa6799203